### PR TITLE
Get deployment working in helm, bump 7dtd docker ver, update readme

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,36 +7,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.7.2
+          version: v3.11.2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.9'
+          check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.0
+        uses: helm/chart-testing-action@v2.4.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-dirs . --charts .
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.4.0
 
       - name: Run chart-testing (install)
-        run: ct install --chart-dirs . --charts .
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: 7dtd
-version: 0.0.1
-appVersion: 0.3.0
+version: 0.0.2
+appVersion: 0.4.4
 description: 7 Days to Die is an open-world game that is a unique combination of first person shooter, survival horror, tower defense, and role-playing games.
 keywords:
   - 7dtd

--- a/README.md
+++ b/README.md
@@ -1,19 +1,98 @@
-# helm-7dtd
-Helm Chart to deploy a 7 days to die server in a Kubernetes cluster. 
+# Helm Chart for a 7 days to die server
 
-### Config
+Helm Chart to deploy a `7 days to die` server in a Kubernetes cluster. 
+
+## Introduction
+
+This [Helm](https://github.com/kubernetes/helm) chart installs [7d2d](https://7daystodie.com/) in a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes cluster 1.10+
+- Helm 3.0.0+
+
+## Installation
+### Add Helm repository
+
+TODO
+### Configure the chart
+
+The following items can be set via `--set` flag during installation or configured by editing the `values.yaml` directly (need to download the chart first).
+
 Feel free to modify values.yaml before installation
 
 values.yaml options:
 
 https://github.com/vinanrra/Docker-7DaysToDie/blob/master/docs/parameters.md#7-days-to-die
 
+### Install the chart
 
-### Install
-`helm install 7daystodie . -f values.yaml --namespace 7days --create-namespace`
+Install the 7d2d helm chart with a release name `my-release`:
 
-### Notes
-docker version of 7dtd pulled from:
+TODO
 
-https://github.com/vinanrra/Docker-7DaysToDie 
-https://hub.docker.com/r/vinanrra/7dtd-server 
+```bash
+helm install my-release alexnuttinck/7d2d
+```
+
+or
+
+```
+helm install 7daystodie . -f values.yaml --namespace 7days --create-namespace
+```
+
+## Uninstallation
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm delete my-release
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the swagger-ui chart and the default values.
+
+| Parameter                                                                   | Description                                                                                                        | Default                         |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------| ------------------------------- |
+| **Image**                                                                   |
+| `image.repository`                                                          | 7d2d Image name                                                                                                    | `vinanrra/7dtd-server`                    |
+| `image.tag`                                                                 | 7d2d Image tag                                                                                                     | `v0.4.4`                              |
+| `image.pullPolicy`                                                          | 7d2d Image pull policy                                                                                             | `IfNotPresent`                  |
+| **Deployment**                                                              |
+| `deployment.replicas`                                                       | Number of replicas                                                                                                 | `1`                             |
+| `deployment.extraEnv`                                                       | Additional environment                                                                                             |  Check the `values.yaml` file for the default values. |
+| **Service**                                                                 |
+| `service.type`                                                              | Type of service for 7d2d frontend                                                                                  | `NodePort`                      |
+| `service.clusterIP`                                                         | internal cluster service IP (set to "-" to pass an empty value)                                                    | `nil`                           |
+| `service.loadBalancerIP`                                                    | LoadBalancerIP if service type is `LoadBalancer`                                                                   | `nil`                           |
+| `service.loadBalancerSourceRanges`                                          | Address that are allowed when svc is `LoadBalancer`                                                                | `[]`                               |
+| `service.annotations`                                                       | Service annotations                                                                                                | `{}`                               |
+| **Ingress**                                                                 |
+| `ingress.enabled`                                                           | Enables Ingress                                                                                                    | `false`                         |
+| `ingress.annotations`                                                       | Ingress annotations                                                                                                | `{}`                               |
+| `ingress.path`                                                              | Path to access frontend                                                                                            | `/`                               |
+| `ingress.hosts`                                                             | Ingress hosts                                                                                                      | `[]`                               |
+| `ingress.tls`                                                               | Ingress TLS configuration                                                                                          | `[]`                               |
+| **ReadinessProbe**                                                          |
+| `readinessProbe`                                                            | Rediness Probe settings                                                                                            | `nil`                           |
+| **LivenessProbe**                                                           |
+| `livenessProbe.httpGet.path`                                                | Liveness Probe settings                                                                                            | `nil`                           |
+| **Resources**                                                               |
+| `resources`                                                                 | CPU/Memory resource requests/limits                                                                                | `{}`                               |
+
+## Credits
+
+Docker versions of 7dtd are pulled from:
+
+* https://github.com/vinanrra/Docker-7DaysToDie 
+* https://hub.docker.com/r/vinanrra/7dtd-server 
+## Contributing
+
+Feel free to contribute by making a [pull request](https://github.com/alexnuttinck/helm-7dtd/pull/new/master).
+
+Please read the official [Contribution Guide](https://github.com/helm/charts/blob/master/CONTRIBUTING.md) from Helm for more information on how you can contribute to this Chart.
+
+## License
+
+[MIT License](/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Helm Chart to deploy a 7 days to die server in a Kubernetes cluster.
 
 ### Install
 Feel free to modify values.yaml before installation
+values.yaml options: https://github.com/vinanrra/Docker-7DaysToDie/blob/master/docs/parameters.md#7-days-to-die
 
 `helm install 7daystodie . -f values.yaml --namespace 7days --create-namespace`
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # helm-7dtd
 Helm Chart to deploy a 7 days to die server in a Kubernetes cluster. 
 
-### Install
+### Config
 Feel free to modify values.yaml before installation
 
 values.yaml options:
 
 https://github.com/vinanrra/Docker-7DaysToDie/blob/master/docs/parameters.md#7-days-to-die
 
+
+### Install
 `helm install 7daystodie . -f values.yaml --namespace 7days --create-namespace`
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@ Helm Chart to deploy a 7 days to die server in a Kubernetes cluster.
 
 ### Install
 Feel free to modify values.yaml before installation
-values.yaml options: https://github.com/vinanrra/Docker-7DaysToDie/blob/master/docs/parameters.md#7-days-to-die
+
+values.yaml options:
+
+https://github.com/vinanrra/Docker-7DaysToDie/blob/master/docs/parameters.md#7-days-to-die
 
 `helm install 7daystodie . -f values.yaml --namespace 7days --create-namespace`
 
 ### Notes
 docker version of 7dtd pulled from:
+
 https://github.com/vinanrra/Docker-7DaysToDie 
 https://hub.docker.com/r/vinanrra/7dtd-server 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # helm-7dtd
 Helm Chart to deploy a 7 days to die server in a Kubernetes cluster. 
 
-WIP...
+### Install
+Feel free to modify values.yaml before installation
+
+`helm install 7daystodie . -f values.yaml --namespace 7days --create-namespace`
+
+### Notes
+docker version of 7dtd pulled from:
+https://github.com/vinanrra/Docker-7DaysToDie 
+https://hub.docker.com/r/vinanrra/7dtd-server 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -60,4 +60,3 @@ spec:
             protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{ end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -28,14 +28,13 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh","-c"]
           env:
-          {{- with .Values.deployment.extraEnv }}
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
+            {{- tpl (.Values.deployment.extraEnv) $ | nindent 10 }}
+          {{- if .Values.livenessProbe }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.livenessProbe.httpGet.port }}
+          {{- end }}
           ports:
           - name: 7dtd-tcp
             containerPort: 26900
@@ -60,4 +59,3 @@ spec:
             protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{ end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -28,11 +28,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh","-c"]
           env:
-          {{- with .Values.deployment.extraEnv }}
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
+            {{- tpl (.Values.deployment.extraEnv) $ | nindent 10 }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.livenessProbe.httpGet.port }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "7dtd.fullname" . }}
+  name: server-{{ template "7dtd.fullname" . }}
   labels:
     app: {{ template "7dtd.name" . }}
     chart: {{ template "7dtd.chart" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -90,7 +90,7 @@ ingress:
   enabled: false
   annotations: {}
   path: /
-  hosts: ["7days.k3s.live"]
+  hosts: []
   tls: []
 
 ## Configure liveness and readiness probes

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: vinanrra/7dtd-server
-  tag: v0.3.0
+  tag: v0.4.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/values.yaml
+++ b/values.yaml
@@ -12,31 +12,53 @@ imagePullSecrets: []
 ##
 deployment:
   replicas: 1
-  extraEnv:
-  # Check the variable that can be passed here: https://github.com/vinanrra/Docker-7DaysToDie/blob/master/docs/parameters.md#7-days-to-die
-    - START_MODE=1
-    - VERSION=stable
-    - PUID=1000
-    - PGID=1000
-    - TimeZone=Europe/Brussels
-    - TEST_ALERT=NO
-    - UPDATE_MODS=NO
-    - ALLOC_FIXES=NO
-    - ALLOC_FIXES_UPDATE
-    - UNDEAD_LEGACY=NO
-    - UNDEAD_LEGACY_VERSION=stable
-    - UNDEAD_LEGACY_UPDATE=NO
-    - ENZOMBIES=NO
-    - ENZOMBIES_ADDON_SNUFKIN=NO
-    - ENZOMBIES_ADDON_ROBELOTO=NO
-    - ENZOMBIES_ADDON_NONUDES=NO
-    - ENZOMBIES_UPDATE=NO
-    - CPM=NO
-    - CPM_UPDATE=NO
-    - BEPINEX=NO
-    - BEPINEX_UPDATE=NO
-    - BACKUP=NO
-    - MONITOR=NO
+  extraEnv: |
+    - name: START_MODE
+      value: "1"
+    - name: VERSION
+      value: "stable"
+    - name: PUID
+      value: "1000"
+    - name: PGID
+      value: "1000"
+    - name: TimeZone
+      value: "America/New_York"
+    - name: TEST_ALERT
+      value: "NO"
+    - name: UPDATE_MODS
+      value: "NO"
+    - name: ALLOC_FIXES
+      value: "NO"
+    - name: ALLOC_FIXES_UPDATE
+      value: "NO"
+    - name: UNDEAD_LEGACY
+      value: "NO"
+    - name: UNDEAD_LEGACY_VERSION
+      value: "stable"
+    - name: UNDEAD_LEGACY_UPDATE
+      value: "NO"
+    - name: ENZOMBIES
+      value: "NO"
+    - name: ENZOMBIES_ADDON_SNUFKIN
+      value: "NO"
+    - name: ENZOMBIES_ADDON_ROBELOTO
+      value: "NO"
+    - name: ENZOMBIES_ADDON_NONUDES
+      value: "NO"
+    - name: ENZOMBIES_UPDATE
+      value: "NO"
+    - name: CPM
+      value: "NO"
+    - name: CPM_UPDATE
+      value: "NO"
+    - name: BEPINEX
+      value: "NO"
+    - name: BEPINEX_UPDATE
+      value: "NO"
+    - name: BACKUP
+      value: "YES"
+    - name: MONITOR
+      value: "NO"
     
 ## Expose the 7dtd service and
 ## Provides options for the service so chart users have the full choice

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: vinanrra/7dtd-server
-  tag: v0.3.0
+  tag: v0.4.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -12,31 +12,53 @@ imagePullSecrets: []
 ##
 deployment:
   replicas: 1
-  extraEnv:
-  # Check the variable that can be passed here: https://github.com/vinanrra/Docker-7DaysToDie/blob/master/docs/parameters.md#7-days-to-die
-    - START_MODE=1
-    - VERSION=stable
-    - PUID=1000
-    - PGID=1000
-    - TimeZone=Europe/Brussels
-    - TEST_ALERT=NO
-    - UPDATE_MODS=NO
-    - ALLOC_FIXES=NO
-    - ALLOC_FIXES_UPDATE
-    - UNDEAD_LEGACY=NO
-    - UNDEAD_LEGACY_VERSION=stable
-    - UNDEAD_LEGACY_UPDATE=NO
-    - ENZOMBIES=NO
-    - ENZOMBIES_ADDON_SNUFKIN=NO
-    - ENZOMBIES_ADDON_ROBELOTO=NO
-    - ENZOMBIES_ADDON_NONUDES=NO
-    - ENZOMBIES_UPDATE=NO
-    - CPM=NO
-    - CPM_UPDATE=NO
-    - BEPINEX=NO
-    - BEPINEX_UPDATE=NO
-    - BACKUP=NO
-    - MONITOR=NO
+  extraEnv: |
+    - name: START_MODE
+      value: "1"
+    - name: TimeZone
+      value: "America/New_York"
+    - name: PUID
+      value: "1000"
+    - name: PGID
+      value: "1000"
+    - name: VERSION
+      value: "stable"
+    - name: TEST_ALERT
+      value: "NO"
+    - name: UPDATE_MODS
+      value: "YESX"
+    - name: ALLOC_FIXES
+      value: "YES"
+    - name: ALLOC_FIXES_UPDATE
+      value: "YES"
+    - name: UNDEAD_LEGACY
+      value: "NO"
+    - name: UNDEAD_LEGACY_VERSION
+      value: "stable"
+    - name: UNDEAD_LEGACY_UPDATE
+      value: "NO"
+    - name: ENZOMBIES
+      value: "NO"
+    - name: ENZOMBIES_ADDON_SNUFKIN
+      value: "NO"
+    - name: ENZOMBIES_ADDON_ROBELOTO
+      value: "NO"
+    - name: ENZOMBIES_ADDON_NONUDES
+      value: "NO"
+    - name: ENZOMBIES_UPDATE
+      value: "NO"
+    - name: CPM
+      value: "NO"
+    - name: CPM_UPDATE
+      value: "NO"
+    - name: BEPINEX
+      value: "NO"
+    - name: BEPINEX_UPDATE
+      value: "NO"
+    - name: BACKUP
+      value: "YES"
+    - name: MONITOR
+      value: "YES"
     
 ## Expose the 7dtd service and
 ## Provides options for the service so chart users have the full choice
@@ -49,7 +71,7 @@ service:
   externalIPs: []
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
-  type: NodePort
+  type: ClusterIP
 
 ## Set the LoadBalancer service type to internal only.
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
@@ -68,7 +90,7 @@ ingress:
   enabled: false
   annotations: {}
   path: /
-  hosts: []
+  hosts: ["7days.k3s.live"]
   tls: []
 
 ## Configure liveness and readiness probes
@@ -82,13 +104,13 @@ ingress:
 #  periodSeconds: 15
 #  timeoutSeconds: 10
 
-livenessProbe:
-  httpGet:
-    path: /
-    port: 7dtd-webadmin
-  initialDelaySeconds: 60
-  periodSeconds: 30
-  timeoutSeconds: 10
+#livenessProbe:
+#  httpGet:
+#    path: /
+#    port: 7dtd-webadmin
+#  initialDelaySeconds: 60
+#  periodSeconds: 30
+#  timeoutSeconds: 10
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
* 7dtd docker container version bump to v0.4.4 from version v0.3.0
* fix an issue where envvars were not working/passing to container
* fix an issue with a trailing {{end}} in deployment
* fix an issue where service name could not generate
* update readme to include basic start command
* remove startup command from container as its included in upstream entrypoint
